### PR TITLE
add option for camel case  property name

### DIFF
--- a/src/main/kotlin/com/maeharin/factlin/core/codegenerator/CodeGenerator.kt
+++ b/src/main/kotlin/com/maeharin/factlin/core/codegenerator/CodeGenerator.kt
@@ -59,7 +59,8 @@ class CodeGenerator(
                     table = table,
                     dialect = dialect,
                     customDefaultValues = extension.customDefaultValues,
-                    customTypeMapper = extension.customTypeMapper
+                    customTypeMapper = extension.customTypeMapper,
+                    useCamelCase = extension.useCamelCase
             ).build()
 
             _generateCode(kClass)

--- a/src/main/kotlin/com/maeharin/factlin/core/kclassbuilder/KClassBuilder.kt
+++ b/src/main/kotlin/com/maeharin/factlin/core/kclassbuilder/KClassBuilder.kt
@@ -2,6 +2,7 @@ package com.maeharin.factlin.core.kclassbuilder
 
 import com.maeharin.factlin.core.Dialect
 import com.maeharin.factlin.core.schemaretriever.Table
+import com.maeharin.factlin.ext.toCamelCase
 import org.slf4j.LoggerFactory
 import java.sql.Types
 
@@ -9,7 +10,8 @@ class KClassBuilder(
         private val table: Table,
         private val dialect: Dialect,
         private val customDefaultValues: List<List<String>>,
-        private val customTypeMapper: Map<String, String>
+        private val customTypeMapper: Map<String, String>,
+        private val useCamelCase: Boolean
 ) {
     val logger = LoggerFactory.getLogger(javaClass)
 
@@ -50,6 +52,7 @@ class KClassBuilder(
 
                     KProp(
                             tableName = table.name,
+                            name = if(useCamelCase) columnMeta.name.toCamelCase(isCapitalizeFirstChar = false) else columnMeta.name,
                             columnName = columnMeta.name,
                             type = type,
                             typeName = columnMeta.typeName,

--- a/src/main/kotlin/com/maeharin/factlin/core/kclassbuilder/KProp.kt
+++ b/src/main/kotlin/com/maeharin/factlin/core/kclassbuilder/KProp.kt
@@ -2,6 +2,7 @@ package com.maeharin.factlin.core.kclassbuilder
 
 data class KProp(
         val tableName: String,
+        val name: String,
         val columnName: String,
         val type: KType,
         private val typeName: String,
@@ -10,12 +11,6 @@ data class KProp(
         val isPrimaryKey: Boolean,
         val comment: String?
 ) {
-    fun name(): String {
-        // todo optional to camel case
-        //return columnName.toCamelCase()
-        return columnName
-    }
-
     /**
      * build default value
      * todo customizable

--- a/src/main/kotlin/com/maeharin/factlin/gradle/FactlinExtension.kt
+++ b/src/main/kotlin/com/maeharin/factlin/gradle/FactlinExtension.kt
@@ -14,4 +14,5 @@ open class FactlinExtension {
     var customDefaultValues: List<List<String>> = emptyList()
     var customTypeMapper: Map<String, String> = emptyMap()
     var schema: String? = null
+    var useCamelCase = false
 }

--- a/src/main/resources/factlin/class.ftl
+++ b/src/main/resources/factlin/class.ftl
@@ -8,7 +8,7 @@ ${import}
 
 data class ${kClass.name()} (
 <#list kClass.props as prop>
-    val ${prop.name()}: ${prop.type.shortName}<#if prop.isNullable()>?</#if> = ${prop.defaultValue()}<#if prop?has_next>,</#if> <#if prop.comment??>// ${prop.comment}</#if>
+    val ${prop.name}: ${prop.type.shortName}<#if prop.isNullable()>?</#if> = ${prop.defaultValue()}<#if prop?has_next>,</#if> <#if prop.comment??>// ${prop.comment}</#if>
 </#list>
 )
 
@@ -16,7 +16,7 @@ fun DbSetupBuilder.insert${kClass.name()}(f: ${kClass.name()}) {
     insertInto("${kClass.tableName}") {
         mappedValues(
             <#list kClass.props as prop>
-                "${prop.columnName}" to f.${prop.name()}<#if prop?has_next>,</#if>
+                "${prop.columnName}" to f.${prop.name}<#if prop?has_next>,</#if>
             </#list>
         )
     }

--- a/src/test/kotlin/com/maeharin/factlin/core/kclassbuilder/KClassBuilderTest.kt
+++ b/src/test/kotlin/com/maeharin/factlin/core/kclassbuilder/KClassBuilderTest.kt
@@ -33,7 +33,7 @@ class KClassBuilderTest {
     @Test
     fun test_build_with_postgres_dialect() {
 
-        val kClass = KClassBuilder(table, Dialect.POSTGRES, emptyList(), emptyMap()).build()
+        val kClass = KClassBuilder(table, Dialect.POSTGRES, emptyList(), emptyMap(), false).build()
 
         assertAll(
                 "assert proper kClass",
@@ -55,7 +55,7 @@ class KClassBuilderTest {
                     assertEquals(false, p.isNullable)
                     assertEquals(true, p.isPrimaryKey)
                     assertEquals("primary key", p.comment)
-                    assertEquals("id", p.name())
+                    assertEquals("id", p.name)
                     assertEquals("0", p.defaultValue())
                 },
                 {
@@ -65,7 +65,7 @@ class KClassBuilderTest {
                     assertEquals(false, p.isNullable)
                     assertEquals(false, p.isPrimaryKey)
                     assertEquals("name long long comment", p.comment)
-                    assertEquals("name", p.name())
+                    assertEquals("name", p.name)
                     assertEquals("\"\"", p.defaultValue())
                 },
                 {
@@ -75,7 +75,7 @@ class KClassBuilderTest {
                     assertEquals(false, p.isNullable)
                     assertEquals(false, p.isPrimaryKey)
                     assertEquals("job name", p.comment)
-                    assertEquals("job", p.name())
+                    assertEquals("job", p.name)
                     // todo enable to "engineer"
                     assertEquals("\"\"", p.defaultValue())
                 },
@@ -86,7 +86,7 @@ class KClassBuilderTest {
                     assertEquals(false, p.isNullable)
                     assertEquals(false, p.isPrimaryKey)
                     assertEquals("activate status", p.comment)
-                    assertEquals("status", p.name())
+                    assertEquals("status", p.name)
                     // todo enable to "ACTIVE"
                     assertEquals("\"\"", p.defaultValue())
                 },
@@ -97,7 +97,7 @@ class KClassBuilderTest {
                     assertEquals(false, p.isNullable)
                     assertEquals(false, p.isPrimaryKey)
                     assertEquals("age", p.comment)
-                    assertEquals("age", p.name())
+                    assertEquals("age", p.name)
                     // todo enable to 30
                     assertEquals("0", p.defaultValue())
                 },
@@ -108,7 +108,7 @@ class KClassBuilderTest {
                     assertEquals(true, p.isNullable)
                     assertEquals(false, p.isPrimaryKey)
                     assertEquals("nick name", p.comment)
-                    assertEquals("nick_name", p.name())
+                    assertEquals("nick_name", p.name)
                     assertEquals("null", p.defaultValue())
                 },
                 {
@@ -118,7 +118,7 @@ class KClassBuilderTest {
                     assertEquals(false, p.isNullable)
                     assertEquals(false, p.isPrimaryKey)
                     assertEquals("my custom type column", p.comment)
-                    assertEquals("my_custom_type_col", p.name())
+                    assertEquals("my_custom_type_col", p.name)
                     assertEquals("\"\"", p.defaultValue())
                 }
         )
@@ -131,7 +131,7 @@ class KClassBuilderTest {
                 listOf("users", "status", "\"ACTIVE\""),
                 listOf("users", "age", "20")
         )
-        val kClass = KClassBuilder(table, Dialect.POSTGRES, customDefaultValues, emptyMap()).build()
+        val kClass = KClassBuilder(table, Dialect.POSTGRES, customDefaultValues, emptyMap(), false).build()
 
         assertAll(
                 {
@@ -150,11 +150,54 @@ class KClassBuilderTest {
     }
 
     @Test
+    fun test_build_with_use_camel_case() {
+        val kClass = KClassBuilder(table, Dialect.POSTGRES, emptyList(), emptyMap(), true).build()
+
+        assertAll(
+            {
+                val p = kClass.props[0]
+                assertEquals("id", p.columnName)
+                assertEquals("id", p.name)
+            },
+            {
+                val p = kClass.props[1]
+                assertEquals("name", p.columnName)
+                assertEquals("name", p.name)
+            },
+            {
+                val p = kClass.props[2]
+                assertEquals("job", p.columnName)
+                assertEquals("job", p.name)
+            },
+            {
+                val p = kClass.props[3]
+                assertEquals("status", p.columnName)
+                assertEquals("status", p.name)
+            },
+            {
+                val p = kClass.props[4]
+                assertEquals("age", p.columnName)
+                assertEquals("age", p.name)
+            },
+            {
+                val p = kClass.props[5]
+                assertEquals("nick_name", p.columnName)
+                assertEquals("nickName", p.name)
+            },
+            {
+                val p = kClass.props[6]
+                assertEquals("my_custom_type_col", p.columnName)
+                assertEquals("myCustomTypeCol", p.name)
+            }
+        )
+    }
+
+    @Test
     fun test_build_with_custom_type_mapper() {
         val customTypeMapper = mapOf<String, String>(
                 "my_custom_type" to "STRING"
         )
-        val kClass = KClassBuilder(table, Dialect.POSTGRES, emptyList(), customTypeMapper).build()
+        val kClass = KClassBuilder(table, Dialect.POSTGRES, emptyList(), customTypeMapper, false).build()
 
         assertAll(
                 {


### PR DESCRIPTION
Thanks for this useful tool !

Currently, Fixture property names are snake case like this.

```kotlin
data class ActorFixture (
    val actor_id: Short = 0, // 
    val first_name: String = "", // 
    val last_name: String = "", // 
    val last_update: LocalDateTime = LocalDateTime.now() // 
)
```

But I think Kotlin class property names are usually camel case. 
So I add the option for generate camel case  code !

```kotlin
data class ActorFixture (
    val actor_id: Short = 0, // 
    val firstName: String = "", // 
    val lastName: String = "", // 
    val lastUpdate: LocalDateTime = LocalDateTime.now() // 
)
```