### PR TITLE
add backward compatibility for custom template

### DIFF
--- a/src/main/kotlin/com/maeharin/factlin/core/kclassbuilder/KProp.kt
+++ b/src/main/kotlin/com/maeharin/factlin/core/kclassbuilder/KProp.kt
@@ -11,6 +11,14 @@ data class KProp(
         val isPrimaryKey: Boolean,
         val comment: String?
 ) {
+
+    /**
+     * for backward compatibility
+     */
+    fun name(): String {
+        return name
+    }
+
     /**
      * build default value
      * todo customizable

--- a/src/main/resources/factlin/class.ftl
+++ b/src/main/resources/factlin/class.ftl
@@ -8,7 +8,7 @@ ${import}
 
 data class ${kClass.name()} (
 <#list kClass.props as prop>
-    val ${prop.name}: ${prop.type.shortName}<#if prop.isNullable()>?</#if> = ${prop.defaultValue()}<#if prop?has_next>,</#if> <#if prop.comment??>// ${prop.comment}</#if>
+    val ${prop.name()}: ${prop.type.shortName}<#if prop.isNullable()>?</#if> = ${prop.defaultValue()}<#if prop?has_next>,</#if> <#if prop.comment??>// ${prop.comment}</#if>
 </#list>
 )
 
@@ -16,7 +16,7 @@ fun DbSetupBuilder.insert${kClass.name()}(f: ${kClass.name()}) {
     insertInto("${kClass.tableName}") {
         mappedValues(
             <#list kClass.props as prop>
-                "${prop.columnName}" to f.${prop.name}<#if prop?has_next>,</#if>
+                "${prop.columnName}" to f.${prop.name()}<#if prop?has_next>,</#if>
             </#list>
         )
     }


### PR DESCRIPTION
Since https://github.com/maeharin/factlin/pull/7,  `Kprop#name` removed.
But if user's custom template reference `name()`, it will broken.

So I added the backward compatibility.