### PR TITLE
fixtureTemplatePath が指定されている場合は FileTemplateLoader を使うように修正

### DIFF
--- a/src/main/kotlin/com/maeharin/factlin/core/codegenerator/CodeGenerator.kt
+++ b/src/main/kotlin/com/maeharin/factlin/core/codegenerator/CodeGenerator.kt
@@ -7,6 +7,7 @@ import com.maeharin.factlin.core.kclassbuilder.KClass
 import com.maeharin.factlin.core.kclassbuilder.KClassBuilder
 import com.maeharin.factlin.core.schemaretriever.Table
 import com.maeharin.factlin.gradle.FactlinExtension
+import freemarker.cache.FileTemplateLoader
 import freemarker.template.Configuration
 import freemarker.template.Template
 import org.slf4j.LoggerFactory
@@ -45,8 +46,10 @@ class CodeGenerator(
 
         // template config
         template = if (extension.fixtureTemplatePath != null) {
-            val config = Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS)
-            config.getTemplate(extension.fixtureTemplatePath)
+            val config = Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS).also {
+                it.templateLoader = FileTemplateLoader(File(extension.fixtureTemplatePath!!), false)
+            }
+            config.getTemplate(extension.fixtureTemplateName)
         } else {
             val config = Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS).also {
                 it.setClassForTemplateLoading(javaClass, "/factlin")

--- a/src/main/kotlin/com/maeharin/factlin/gradle/FactlinExtension.kt
+++ b/src/main/kotlin/com/maeharin/factlin/gradle/FactlinExtension.kt
@@ -8,6 +8,7 @@ open class FactlinExtension {
     var fixtureOutputDir = "src/test/kotlin/com/maeharin/factlin/fixtures"
     var fixturePackageName = "com.maeharin.factlin.fixtures"
     var fixtureTemplatePath: String? = null
+    var fixtureTemplateName: String? = null
     var includeTables: List<String>? = null
     var excludeTables: List<String> = emptyList()
     var cleanOutputDir = false


### PR DESCRIPTION
- M1 Mac で factlin が動かなくなっていたのを修正
- fixtureTemplatePath を指定した場合、gradle のルートディレクトリが指定されてしまう問題を修正しました
- fixtureTemplatePath は path のみを指定するようにしました
- fixtureTemplateName を追加し、テンプレートのファイル名を指定できるようにしました